### PR TITLE
Fix grunt watch not processing/reloading when Sass files changed

### DIFF
--- a/app/templates/_gruntfile.js
+++ b/app/templates/_gruntfile.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
                 },
             },
             css: {
-                files: ['public/css/**'],
+                files: ['app/styles/**', 'public/styles/**'],
+                tasks: ['compass'],
                 options: {
                     livereload: true
                 }


### PR DESCRIPTION
I noticed the `grunt watch` task didn't run when changes were made to the `.scss` files and figured it was a misconfiguration on the `gruntfile`.

It should work properly now.
