### PR TITLE
Update config function in order to read json 'partial' configs

### DIFF
--- a/app/templates/config/config.js
+++ b/app/templates/config/config.js
@@ -6,7 +6,11 @@ var _ = require('underscore'),
 // Load configurations
 // Set the node environment variable if not set before
 process.env.NODE_ENV = ~fs.readdirSync('./config/env').map(function(file) {
-    return file.slice(0, -3);
+    if (file === 'all.js') {
+    	return file.slice(0, -3);		
+	}
+	// case json file
+	return file.slice(0, -5);
 }).indexOf(process.env.NODE_ENV) ? process.env.NODE_ENV : 'development';
 
 // Extend the base configuration in all.js with environment


### PR DESCRIPTION
Hi! I noticed that the generated app wasn't able to use the NODE_ENV variables correctly, which was driving me nuts. Found out that it's because the config.js is slicing all the configs as they were .js, but most of them are json. That quick change made it possible to use production environment correctly.
