### PR TITLE
Update express.js to fit new MongoStore constructor

### DIFF
--- a/app/templates/config/express.js
+++ b/app/templates/config/express.js
@@ -62,7 +62,7 @@ module.exports = function(app, db) {
     app.use(session({
         secret: config.sessionSecret,
         store: new MongoStore({
-            db: db.connection.db,
+            mongooseConnection: db.connection,
             collection: config.sessionCollection
         })
     }));


### PR DESCRIPTION
MongoStore update their constructor and use the parameter 'mongooseConnection' to re-use a mongoose connection to the database.
Details are in the github project [README file](https://github.com/kcbanner/connect-mongo#re-use-a-mongoose-connection)

It fixes the #21.
